### PR TITLE
Suggest use of 5.1 TSan backport in tutorial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,26 @@
 FROM --platform=linux/amd64 ocaml/opam:debian-12-opam as base
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 7dbbdf38edcb4e6e73461f0e7bb2ada6c9314c2f && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard afb1f0d6b01bb1b04cb6c8b68b30cbbbfd58c0fa && opam update
 WORKDIR src
 RUN sudo apt install -y libunwind-dev linux-perf
 
 FROM base as tsan
-RUN opam switch create tsan ocaml-option-tsan
-RUN opam pin add ocaml-compiler-libs.v0.12.5 git+https://github.com/art-w/ocaml-compiler-libs.git\#ocaml-5.2-trunk
-RUN opam pin add ppxlib.0.31.0 git+https://github.com/panglesd/ppxlib.git\#trunk-support-502
+RUN opam switch create 5.1.0~rc3+tsan
 COPY vendor/ocaml-git/*.opam vendor/ocaml-git/
 RUN opam pin -yn --with-version=3.13.0 vendor/ocaml-git
 COPY tutorial.opam .
-RUN opam install --switch=tsan --deps-only -t .
+RUN opam install --deps-only -t .
 
 FROM base as ocaml510fp
-RUN opam switch create 5.1.0~rc2+fp ocaml-variants.5.1.0~rc2+options ocaml-option-fp
+RUN opam switch create 5.1.0~rc3+fp ocaml-variants.5.1.0~rc3+options ocaml-option-fp
 COPY vendor/ocaml-git/*.opam vendor/ocaml-git/
 RUN opam pin -yn --with-version=3.13.0 vendor/ocaml-git
 COPY tutorial.opam .
-RUN opam install --switch=5.1.0~rc2+fp --deps-only -t .
+RUN opam install --switch=5.1.0~rc3+fp --deps-only -t .
 
-COPY --from=tsan /home/opam/.opam/tsan /home/opam/.opam/tsan
-RUN sed -i 's/installed-switches: "5.1.0~rc2+fp"/installed-switches: ["5.1.0~rc2+fp" "tsan"]/' ../.opam/config
+COPY --from=tsan /home/opam/.opam/5.1.0~rc3+tsan /home/opam/.opam/5.1.0~rc3+tsan
+RUN sed -i 's/installed-switches: "5.1.0~rc3+fp"/installed-switches: ["5.1.0~rc3+fp" "5.1.0~rc3+tsan"]/' ../.opam/config
 
 RUN opam install ocaml-lsp-server ocamlformat
 ENTRYPOINT [ "opam", "exec", "--" ]

--- a/doc/prereqs.md
+++ b/doc/prereqs.md
@@ -3,13 +3,13 @@
 You will need OCaml 5.1 or later, which can be installed using [opam](https://opam.ocaml.org/):
 
 ```sh
-opam switch create 5.1.0~rc2
+opam switch create 5.1.0~rc3
 ```
 
 For profiling with `perf` (Linux-only), it may be helpful to use a compiler with frame-pointers enabled instead, like this:
 
 ```sh
-opam switch create 5.1.0~rc2+fp ocaml-variants.5.1.0~rc2+options ocaml-option-fp
+opam switch create 5.1.0~rc3+fp ocaml-variants.5.1.0~rc3+options ocaml-option-fp
 ```
 
 This repository uses Git submodules. Make sure they're enabled with:

--- a/doc/prereqs.md
+++ b/doc/prereqs.md
@@ -52,9 +52,9 @@ It takes a while to build, so it's a good idea to do that ahead of time.
 For finding races, you might also want a compiler with `tsan` enabled (currently this uses OCaml 5.2-trunk):
 ```sh
 sudo apt install libunwind-dev
-opam switch create tsan ocaml-option-tsan
+opam switch create 5.1.0~rc3+tsan
 ```
-Warning: you will need plently of memory to compile packages in this switch, and it may fail silently if there isn't enough.
+Warning: you will need plenty of memory to compile some packages on this switch, and the build will fail if it runs out of memory.
 
 The Docker image includes a switch with ThreadSanitizer installed automatically.
 


### PR DESCRIPTION
The switch `5.1.0~rc3+tsan` has recently made it to opam (https://github.com/ocaml/opam-repository/pull/24358), so it might be more convenient to use it than to work on trunk.

Also, OOM during package build should not fail silently, but should be reported by opam.