### PR TITLE
Make tsan an optional extra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,16 @@ RUN cd ~/opam-repository && git fetch origin master && git reset --hard afb1f0d6
 WORKDIR src
 RUN sudo apt install -y libunwind-dev linux-perf
 
-FROM base as tsan
-RUN opam switch create 5.1.0~rc3+tsan
-COPY vendor/ocaml-git/*.opam vendor/ocaml-git/
-RUN opam pin -yn --with-version=3.13.0 vendor/ocaml-git
-COPY tutorial.opam .
-RUN opam install --deps-only -t .
+# 
+# To try tsan, uncomment the following block and ALSO the block below
+# Note that at time writing this doesn't work on M1/M2 macs
+#
+#FROM base as tsan
+#RUN opam switch create 5.1.0~rc3+tsan
+#COPY vendor/ocaml-git/*.opam vendor/ocaml-git/
+#RUN opam pin -yn --with-version=3.13.0 vendor/ocaml-git
+#COPY tutorial.opam .
+#RUN opam install --deps-only -t .
 
 FROM base as ocaml510fp
 RUN opam switch create 5.1.0~rc3+fp ocaml-variants.5.1.0~rc3+options ocaml-option-fp
@@ -19,8 +23,11 @@ RUN opam pin -yn --with-version=3.13.0 vendor/ocaml-git
 COPY tutorial.opam .
 RUN opam install --switch=5.1.0~rc3+fp --deps-only -t .
 
-COPY --from=tsan /home/opam/.opam/5.1.0~rc3+tsan /home/opam/.opam/5.1.0~rc3+tsan
-RUN sed -i 's/installed-switches: "5.1.0~rc3+fp"/installed-switches: ["5.1.0~rc3+fp" "5.1.0~rc3+tsan"]/' ../.opam/config
+#
+# Also uncomment this block to try tsan
+#
+#COPY --from=tsan /home/opam/.opam/5.1.0~rc3+tsan /home/opam/.opam/5.1.0~rc3+tsan
+#RUN sed -i 's/installed-switches: "5.1.0~rc3+fp"/installed-switches: ["5.1.0~rc3+fp" "5.1.0~rc3+tsan"]/' ../.opam/config
 
 RUN opam install ocaml-lsp-server ocamlformat
 ENTRYPOINT [ "opam", "exec", "--" ]

--- a/doc/prereqs.md
+++ b/doc/prereqs.md
@@ -56,7 +56,7 @@ opam switch create 5.1.0~rc3+tsan
 ```
 Warning: you will need plenty of memory to compile some packages on this switch, and the build will fail if it runs out of memory.
 
-The Docker image includes a switch with ThreadSanitizer installed automatically.
+The Docker image includes commented-out blocks that install a switch with ThreadSanitizer. Please uncomment the two blocks to try this. Note that at time of writing this does not work on M1/M2 macs.
 
 ## Next
 


### PR DESCRIPTION
The tsan switch takes longer to make and uses a fair bit more memory. In order to try to ensure the container builds successfully, comment out the tsan switch creation. Once we get to the part of the tutorial that involves tsan we can suggest people try it out at that point.